### PR TITLE
range localization

### DIFF
--- a/lang/en-EN.json
+++ b/lang/en-EN.json
@@ -1681,7 +1681,7 @@
 				},
 				"label": "Qualities"
 			},
-			"range": "Range",
+			"range.label": "Range",
 			"special": "Special"
 		},
 		"GROUPS": {


### PR DESCRIPTION
Im not sure why .label was added but its there in FR so I did the same in ENG so that it gets picked up.

I dont know what special is for as I dont see the reference to it anywhere but that also is .label in FR (but not changed in this commit)